### PR TITLE
use filestore

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -158,18 +158,23 @@ function(
                     annotations: annotations
                 },
                 spec: {
-                    volumes:
-                    - name: 'skiff-files'
-                      persistentVolumeClaim:
-                        claimName: 'skiff-files-server-experimental-covid-sim'
+                    volumes: [
+                        { 
+                            name: 'skiff-files',
+                            persistentVolumeClaim: {
+                                claimName: 'skiff-files-server-experimental-covid-sim'
+                            }
+                        }
+                    ],
                     containers: [
                         {
                             name: fullyQualifiedName + '-api',
                             image: apiImage,
-                            volumeMounts:
-                            - mountPath: '/skiff_files'
-                              name: 'skiff-files'
+                            volumeMounts: {
+                              mountPath: '/skiff_files',
+                              name: 'skiff-files',
                               readOnly: true
+                            },
                             readinessProbe: apiHealthCheck,
                             # The liveness probe restarts the container. Only
                             # restart if the TCP socket has been unresponsive

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -162,7 +162,7 @@ function(
                         { 
                             name: 'skiff-files',
                             persistentVolumeClaim: {
-                                claimName: 'skiff-files-server-experimental-covid-sim'
+                                claimName: 'skiff-files-server-covid-sim'
                             }
                         }
                     ],

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -158,10 +158,18 @@ function(
                     annotations: annotations
                 },
                 spec: {
+                    volumes:
+                    - name: 'skiff-files'
+                      persistentVolumeClaim:
+                        claimName: 'skiff-files-server-experimental-covid-sim'
                     containers: [
                         {
                             name: fullyQualifiedName + '-api',
                             image: apiImage,
+                            volumeMounts:
+                            - mountPath: '/skiff_files'
+                              name: 'skiff-files'
+                              readOnly: true
                             readinessProbe: apiHealthCheck,
                             # The liveness probe restarts the container. Only
                             # restart if the TCP socket has been unresponsive
@@ -174,13 +182,7 @@ function(
                                     cpu: '1.0',
                                     memory: '21Gi'
                                 }
-                            },
-                            env: [
-                                {
-                                    name: 'DATASET_URL',
-                                    value: 'https://storage.googleapis.com/skiff-models/covid-sim/demo-data-partial/demo_data_01.zip'
-                                },
-                            ]
+                            }
                         },
                         {
                             name: fullyQualifiedName + '-proxy',

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -170,11 +170,13 @@ function(
                         {
                             name: fullyQualifiedName + '-api',
                             image: apiImage,
-                            volumeMounts: {
-                              mountPath: '/skiff_files',
-                              name: 'skiff-files',
-                              readOnly: true
-                            },
+                            volumeMounts: [
+                                {
+                                    mountPath: '/skiff_files',
+                                    name: 'skiff-files',
+                                    readOnly: true
+                                }
+                            ],
                             readinessProbe: apiHealthCheck,
                             # The liveness probe restarts the container. Only
                             # restart if the TCP socket has been unresponsive

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -31,6 +31,9 @@ RUN sh ./install.sh
 
 RUN git clone https://github.com/Shaul1321/covid-ai2
 
+# Use a specific version of the repo (because the one following this one has a bug/typo.)
+RUN cd covid-12 && git reset --hard 5c8a9f2f21392bdd72c8197940152da68213de7a
+
 WORKDIR /usr/src/app/covid-ai2
 RUN ls
 # download data & run streamlit

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -31,10 +31,11 @@ RUN sh ./install.sh
 
 RUN git clone https://github.com/Shaul1321/covid-ai2
 
-# Use a specific version of the repo (because the one following this one has a bug/typo.)
-RUN cd covid-12 && git reset --hard 5c8a9f2f21392bdd72c8197940152da68213de7a
-
 WORKDIR /usr/src/app/covid-ai2
+
+# Use a specific version of the repo (because the one following this one has a bug/typo.)
+RUN git reset --hard 5c8a9f2f21392bdd72c8197940152da68213de7a
+
 RUN ls
 # download data & run streamlit
 COPY startup.sh .

--- a/api/startup.sh
+++ b/api/startup.sh
@@ -3,6 +3,6 @@
 # Dataset files are expected to be available at this /skiff_files location.
 # But, the application reads files from /usr/src/app/covid-ai2/data so this
 # symlink lets it find the files it needs.
-ln -s /skiff_files/apps/covid-sim/demo_data /usr/src/app/covid-ai2/data
+ln -s /skiff_files/apps/covid-sim/demo_data_01 /usr/src/app/covid-ai2/data
 
 streamlit run demo.py --server.enableCORS false

--- a/api/startup.sh
+++ b/api/startup.sh
@@ -3,6 +3,6 @@
 # Dataset files are expected to be available at this /skiff_files location.
 # But, the application reads files from /usr/src/app/covid-ai2/data so this
 # symlink lets it find the files it needs.
-ln -s /skiff_files/apps/covid-sim/demo_data_01 /usr/src/app/covid-ai2/data
+ln -s /skiff_files/apps/covid-sim/demo_data /usr/src/app/covid-ai2/data
 
 streamlit run demo.py --server.enableCORS false

--- a/api/startup.sh
+++ b/api/startup.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-DATASET_NAME="${DATASET_NAME:-data}"
-DATASET_URL="${DATASET_URL:-https://storage.googleapis.com/skiff-models/covid-sim/demo-data-partial/demo_data_01.zip}"
-LOCAL_DATASET_DIR=/usr/src/app/covid-ai2
 
-echo "INFO: Downloading dataset from ${DATASET_URL})..."
-wget ${DATASET_URL} || exit 1
-unzip demo_data.zip -d ${LOCAL_DATASET_DIR}/${DATASET_NAME}
+# Dataset files are expected to be available at this /skiff_files location.
+# But, the application reads files from /usr/src/app/covid-ai2/data so this
+# symlink lets it find the files it needs.
+ln -s /skiff_files/apps/covid-sim/demo_data /usr/src/app/covid-ai2/data
 
 streamlit run demo.py --server.enableCORS false


### PR DESCRIPTION
I set up an experimental instance of Google Filestore with volume "skiff_files" and manually downloaded and unzipped the file https://storage.googleapis.com/skiff-models/covid-sim/demo-data-partial/demo_data.zip to the path /skiff_files/apps/covid-sim/demo_data.

This change makes the covid-sim app use these files in a read-only way.

To make it work, I updated the startup script to make /usr/src/app/covid-ai2/data be a symlink to the above location, so the files are just magically there when the demo.py script runs.

I also updated api/Dockerfile to rewind the repo https://github.com/Shaul1321/covid-ai2 to a version before [a bug was introduced](https://github.com/Shaul1321/covid-ai2/commit/28c35783875db8fdd25a61a0ece531c6a2265104) -- `wirte` is s typo. (This dependency on Shaul1321/covid-ai2 needs to go away ;-))

This all now comes together nicely in a skiff environment at https://covid-sim.michalg-use-filestore.apps.allenai.org/ and doesn't require downloading any files at startup.

> <img width="1268" alt="image" src="https://user-images.githubusercontent.com/19393950/85904728-54a52600-b7be-11ea-8a51-8459cb6da0bf.png">

(Separately, I'm extracting the larger zip file demo_data_01.zip to /skiff_files/apps/covid-sim/demo_data_01 so we can try that out soon.)

