### PR TITLE
use filestore, attempt 2

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -187,7 +187,7 @@ function(
                             resources: {
                                 requests: {
                                     cpu: '1.0',
-                                    memory: '21Gi'
+                                    memory: '70Gi'
                                 }
                             }
                         },

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -158,10 +158,25 @@ function(
                     annotations: annotations
                 },
                 spec: {
+                    volumes: [
+                        { 
+                            name: 'skiff-files',
+                            persistentVolumeClaim: {
+                                claimName: 'skiff-files-server-covid-sim'
+                            }
+                        }
+                    ],
                     containers: [
                         {
                             name: fullyQualifiedName + '-api',
                             image: apiImage,
+                            volumeMounts: [
+                                {
+                                    mountPath: '/skiff_files',
+                                    name: 'skiff-files',
+                                    readOnly: true
+                                }
+                            ],
                             readinessProbe: apiHealthCheck,
                             # The liveness probe restarts the container. Only
                             # restart if the TCP socket has been unresponsive
@@ -174,13 +189,7 @@ function(
                                     cpu: '1.0',
                                     memory: '21Gi'
                                 }
-                            },
-                            env: [
-                                {
-                                    name: 'DATASET_URL',
-                                    value: 'https://storage.googleapis.com/skiff-models/covid-sim/demo-data-partial/demo_data_01.zip'
-                                },
-                            ]
+                            }
                         },
                         {
                             name: fullyQualifiedName + '-proxy',

--- a/api/startup.sh
+++ b/api/startup.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-DATASET_NAME="${DATASET_NAME:-data}"
-DATASET_URL="${DATASET_URL:-https://storage.googleapis.com/skiff-models/covid-sim/demo-data-partial/demo_data_01.zip}"
-LOCAL_DATASET_DIR=/usr/src/app/covid-ai2
 
-echo "INFO: Downloading dataset from ${DATASET_URL})..."
-wget ${DATASET_URL} || exit 1
-unzip demo_data_01.zip -d ${LOCAL_DATASET_DIR}/${DATASET_NAME}
+# Dataset files are expected to be available at this /skiff_files location.
+# But, the application reads files from /usr/src/app/covid-ai2/data so this
+# symlink lets it find the files it needs.
+ln -s /skiff_files/apps/covid-sim/demo_data /usr/src/app/covid-ai2/data
 
 streamlit run demo.py --server.enableCORS false

--- a/api/startup.sh
+++ b/api/startup.sh
@@ -3,6 +3,6 @@
 # Dataset files are expected to be available at this /skiff_files location.
 # But, the application reads files from /usr/src/app/covid-ai2/data so this
 # symlink lets it find the files it needs.
-ln -s /skiff_files/apps/covid-sim/demo_data /usr/src/app/covid-ai2/data
+ln -s /skiff_files/apps/covid-sim/demo_data_01 /usr/src/app/covid-ai2/data
 
 streamlit run demo.py --server.enableCORS false


### PR DESCRIPTION
Here's a re-try of https://github.com/allenai/covid-sim/pull/2 starting from master after some changes were made there.

The container appears to come up with the large dataset files, but then gets evicted because:

> The node was low on resource: memory. Container covid-sim-michalg-use-filestore-2-api was using 46593064Ki, which exceeds its request of 21Gi. 

So I'm not sure what to do about that... ¯\\\_(ツ)\_/¯

The "high-mem" nodes that this app lands on have a max of "49.7 GB". Does this need more memory than that?

Could it be that streamlit is holding several copies of the index in memory?

I'm going to delete the environment in Skiff so it doesn't repeatedly fail.